### PR TITLE
fixed migrations for ERC777

### DIFF
--- a/contracts/Truffle777.sol
+++ b/contracts/Truffle777.sol
@@ -3,8 +3,8 @@ pragma solidity >=0.4.21 <0.6.0;
 import "../node_modules/openzeppelin-solidity/contracts/token/ERC777/ERC777.sol";
 
 contract Truffle777 is ERC777 {
-    constructor(string memory name, string memory symbol, address[] memory defaultOperators)
-    ERC777(name, symbol, defaultOperators) public {
+    constructor () public ERC777("Truffle777", "T7", new address[](0)) {
+        _mint(msg.sender, msg.sender, 10000 * 10 ** 18, "", "");
     }
-
 }
+

--- a/migrations/4_deploy_777.js
+++ b/migrations/4_deploy_777.js
@@ -1,15 +1,12 @@
 const Truffle777 = artifacts.require('Truffle777');
 
-require('openzeppelin-test-helpers/configure')({ web3 });
+require('../node_modules/openzeppelin-test-helpers/configure')({ web3 });
 
-const { singletons } = require('openzeppelin-test-helpers');
+const { singletons } = require('../node_modules/openzeppelin-test-helpers');
 
-const name = "Truffle777";
-const symbol = "T7";
-const defaultOperators = [];
 
 module.exports = async function(deployer, network, accounts) {
   const erc1820 = await singletons.ERC1820Registry(accounts[0]);
 
-  deployer.deploy(Truffle777, name, symbol, defaultOperators);
+  await deployer.deploy(Truffle777);
 };


### PR DESCRIPTION
-fixed constructor
-added _mint call in the constructor to initialize total supply
-pointed the require statements to the right path
-add await to deployer.deploy